### PR TITLE
Allow partial tag list to be retrieved

### DIFF
--- a/Tests/Id3TagsReaderTest.php
+++ b/Tests/Id3TagsReaderTest.php
@@ -26,7 +26,20 @@ class GenerateCvCommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(file_get_contents(__DIR__ . $this->albumCover), $image[1]);
     }
 
-    public function testGetId3TagsArray()
+    /**
+     * Test readTags with partial tag array
+     */
+    public function testGetId3TagsArrayWithPartialArray()
+    {
+        $id3 = new Id3TagsReader(fopen(__DIR__ . $this->mp3File, "rb"));
+        $id3->readTags(array_flip(["TIT2"]));
+        $id3Tags = $id3->getId3Array();
+
+        $this->assertEquals($id3Tags["TIT2"]["body"], 'Piranha');
+        $this->assertCount(1, $id3Tags);
+    }
+
+    public function testGetId3TagsArrayWithCompleteArray()
     {
         $id3Tags = $this->id3->getId3Array();
 


### PR DESCRIPTION
The idea is to avoid full retrieval of tags if not necessary.
In my case, it was necessary to avoid loading of a corrupted Image attached in APIC, that was causing application to crach unexpectedly with certains MP3s.

No BC break, `readAllTags` continue to work as expected, redirecting to `readTags` with list from `Id3Tags::getId3Tags()`

Attached test is running a different Id3TagsReader instance to permit partial load.
